### PR TITLE
Optimize Dockerfile Layering for Faster Builds and Caching Efficiency

### DIFF
--- a/code/meme-generator/Dockerfile
+++ b/code/meme-generator/Dockerfile
@@ -1,4 +1,4 @@
 FROM python:3.10-slim
-COPY . .
 RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
 CMD ["python", "main.py"]


### PR DESCRIPTION
Layering and Caching 

The order of commands in a Dockerfile affects caching. Since COPY . . copies everything from the current directory into the Docker image, it's usually better to place this command after installing dependencies (pip install) to take advantage of Docker's layer caching. This way, if your dependencies don't change frequently, Docker can reuse the cached layer for faster builds.